### PR TITLE
Updated types of Vault Response

### DIFF
--- a/lib/types/vault-response.ts
+++ b/lib/types/vault-response.ts
@@ -1,13 +1,22 @@
 import {Dictionary} from '.';
 
+export type WrapInfo = {
+    token: string,
+    accessor: string,
+    ttl: number,
+    creation_time: string,
+    creation_path: string,
+    wrapped_accessor: string,
+}
+
 export interface VaultResponse extends Dictionary<any> {
     request_id: string;
     lease_id: string;
     renewable: boolean;
     lease_duration: number;
-    data: Dictionary<any>;
+    data: Dictionary<any> | null;
     metadata?: Dictionary<any>;
-    wrap_info?: Dictionary<any> | null;
+    wrap_info?: WrapInfo | null;
     warnings?: any | null;
     auth?: any | null;
     statusCode: number;


### PR DESCRIPTION
Hello,

Thank you for you library. 

This is a little update to improve the type declaration of the `wrap_info` property and the data property that can be null when the response is wrapped. 

Let me know if you have any question or change request